### PR TITLE
typo fix: age => height

### DIFF
--- a/index.html
+++ b/index.html
@@ -1467,7 +1467,7 @@ pre {
       </div>
 
     <figcaption>
-      <a href="#single_baselines_bad" class="figure-number">3</a>: Example illustrating the downsides of a single baseline for Shapley values.  Feature 1 corresponds to age (inches), feature 2 is weight (pounds), and feature 3 is gender (0 is male, 1 is female).  The first baseline is an all-zero baseline.  The second is an average feature value baseline.
+      <a href="#single_baselines_bad" class="figure-number">3</a>: Example illustrating the downsides of a single baseline for Shapley values.  Feature 1 corresponds to height (inches), feature 2 is weight (pounds), and feature 3 is gender (0 is male, 1 is female).  The first baseline is an all-zero baseline.  The second is an average feature value baseline.
     </figcaption>
     </figure>
 


### PR DESCRIPTION
It looks this is a typo, which could be quite confusing.